### PR TITLE
feat: access the container desktop over noVNC instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The `qrb_ros_sim_gazebo` is a ROS 2 package. It provides Gazebo integration and 
   * [Set up development environment](#-set-up-development-environment)
   * [Build from Source](#-build-from-source)
   * [Usage](#-usage)
+  * [Troubleshooting](#-troubleshooting)
   * [Contributing](#-contributing)
   * [Contributors](#%EF%B8%8F-contributors)
   * [License](#-license)
@@ -373,22 +374,16 @@ cd qrb_ros_simulation
 chmod +x scripts/docker_build.sh
 ./scripts/docker_build.sh
 ```
+The base image is pulled from the AWS ECR Public mirror of the Docker official images, which works without configuring a registry mirror in the docker daemon. If `docker.io` is reachable from your network, you can use it instead with `docker build --build-arg ROS_BASE_IMAGE=ros:jazzy-ros-base ...`.
 2. Start a docker container
 ```bash
 chmod +x scripts/docker_run.sh
 ./scripts/docker_run.sh
 ```
-3. Enable SSH service in the docker container
-```bash
-# set the password of user root
-(docker) passwd
-# enable SSH service
-(docker) service ssh start
-```
-4. In a separate terminal, login to the docker container by SSH
-```bash
-ssh -X -p 222 root@your_host_ip
-```
+The container starts a remote desktop (XFCE4) served over noVNC. The script prints the URL and password to use, e.g. `http://your_host_ip:6080/vnc.html` (default password `qrbrossim`, override with `VNC_PASSWORD=yourpassword ./scripts/docker_run.sh`).
+
+3. Open that URL in a browser and click *Connect*, entering the VNC password when prompted.
+4. Inside the remote desktop, open a terminal (right-click desktop > *Open Terminal Here*, or use the Applications menu) to run the commands below.
 
 Next, you can follow the steps of [​Build from source](#-build-from-source)​​ and ​[​Usage](#-usage) to launch the simulation environment within the docker container.
 
@@ -458,6 +453,24 @@ cd ~/qrb_ros_simulation_ws
 source install/local_setup.sh
 ros2 launch qrb_ros_sim_gazebo gazebo_rml_63_gripper_load_controller.launch.py
 ```
+
+---
+
+## 🔧 Troubleshooting
+
+### 🔹 `docker build` fails because the base image cannot be pulled
+
+If the build fails while pulling the base image, with an error such as:
+
+```
+Get "https://registry-1.docker.io/v2/": http: server gave HTTP response to HTTPS client
+```
+
+your network cannot reach Docker Hub directly. This project's dockerfile already defaults to the [AWS ECR Public mirror of the Docker official images](https://gallery.ecr.aws/docker/library/ros), so try the default build first. If your network blocks that too, configure the docker daemon to use a registry mirror or an HTTP proxy — see the official documentation:
+
+- [Registry mirror configuration](https://docs.docker.com/docker-hub/mirror/) — the `registry-mirrors` option in `/etc/docker/daemon.json`
+- [dockerd reference](https://docs.docker.com/reference/cli/dockerd/) — full `daemon.json` reference
+- [Configure the daemon to use a proxy](https://docs.docker.com/engine/daemon/proxy/) — if your network requires an HTTP/HTTPS proxy instead of a mirror
 
 ---
 

--- a/dockerfile/entrypoint.sh
+++ b/dockerfile/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+VNC_PASSWORD="${VNC_PASSWORD:-qrbrossim}"
+
+mkdir -p /root/.vnc
+
+echo "${VNC_PASSWORD}" | vncpasswd -f > /root/.vnc/passwd
+chmod 600 /root/.vnc/passwd
+
+# clean up any stale lock/socket files from a previous container run
+vncserver -kill :1 >/dev/null 2>&1 || true
+rm -f /tmp/.X1-lock /tmp/.X11-unix/X1
+
+vncserver :1 -geometry "${RESOLUTION}" -depth 24
+
+echo "noVNC web UI: http://<host_ip>:6080/vnc.html"
+
+exec websockify --web=/usr/share/novnc/ 0.0.0.0:6080 localhost:5901

--- a/dockerfile/qrb_ros_simulation.dockerfile
+++ b/dockerfile/qrb_ros_simulation.dockerfile
@@ -1,4 +1,6 @@
-FROM ros:jazzy-ros-base
+# Pull the ROS base image from the AWS ECR Public mirror of Docker official images
+ARG ROS_BASE_IMAGE=public.ecr.aws/docker/library/ros:jazzy-ros-base
+FROM ${ROS_BASE_IMAGE}
 
 LABEL maintainer="Weijie Shen <weijshen@qti.qualcomm.com>"
 LABEL description="this docker file is for running QRB ROS Simulation on host."
@@ -11,9 +13,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-jazzy-ros2-controllers \
     && rm -rf /var/lib/apt/lists/*
 
-# install and config ssh
-RUN apt-get update \
-    && apt-get install -y openssh-server \
-    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
-    && sed -i 's/#Port 22/Port 222/' /etc/ssh/sshd_config
+# install remote desktop (XFCE4) + web-based VNC client (noVNC) so Gazebo/RViz
+# GUIs can be used from a browser
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xfce4 \
+    xfce4-terminal \
+    dbus-x11 \
+    tigervnc-standalone-server \
+    tigervnc-common \
+    tigervnc-tools \
+    novnc \
+    websockify \
+    && rm -rf /var/lib/apt/lists/*
 
+# no GPU is passed into the container, force Mesa's software rasterizer
+# (llvmpipe) so OpenGL apps (Gazebo/RViz) can still initialize a context
+ENV LIBGL_ALWAYS_SOFTWARE=1
+
+ENV RESOLUTION=1920x1080
+
+RUN mkdir -p /root/.vnc \
+    && printf '#!/bin/bash\nunset SESSION_MANAGER\nunset DBUS_SESSION_BUS_ADDRESS\nexec dbus-launch --exit-with-session startxfce4\n' > /root/.vnc/xstartup \
+    && chmod +x /root/.vnc/xstartup
+
+COPY dockerfile/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 5901 6080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -6,7 +6,14 @@
 docker_name="qrb_ros_simulation"
 docker_tag="latest"
 
+# override the default VNC password by exporting VNC_PASSWORD before running
+# this script, e.g. `VNC_PASSWORD=mypassword ./scripts/docker_run.sh`
+vnc_password="${VNC_PASSWORD:-qrbrossim}"
+
+echo "Open http://<host_ip>:6080/vnc.html in your browser to access the desktop (password: ${vnc_password})"
+
 docker run -it --rm \
   --name ${docker_name}_container \
   --network host \
+  -e VNC_PASSWORD="${vnc_password}" \
 	${docker_name}:${docker_tag}


### PR DESCRIPTION
Serve an XFCE4 desktop through TigerVNC and noVNC so the Gazebo and RViz GUIs can be used from a browser, removing the need for an X server and an SSH client on the host.